### PR TITLE
Add Informatica PowerCenter ETL implementation files

### DIFF
--- a/Informatica_PowerCenter_Mapping.xml
+++ b/Informatica_PowerCenter_Mapping.xml
@@ -1,0 +1,417 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Informatica PowerCenter Mapping Design for Financial Balance ETL Pipeline -->
+<!-- Based on pseudo_ETL_code.txt - BMO Financial Balance Processing -->
+
+<POWERMART>
+  <REPOSITORY NAME="BMO_FINANCIAL_REPO" VERSION="9.6.1" CODEPAGE="UTF-8">
+    
+    <!-- FOLDER DEFINITION -->
+    <FOLDER NAME="BMO_BALANCE_ETL" GROUP="" OWNER="DEVELOPER" SHARED="SHARED" 
+           DESCRIPTION="Financial Balance ETL Pipeline - Informatica PowerCenter Implementation">
+      
+      <!-- SOURCE DEFINITION: Flat File mrp0455_inv_gl.txt -->
+      <SOURCE NAME="SQ_mrp0455_inv_gl" DATABASETYPE="Flat File" DBDNAME="$PMSourceFileDir">
+        <SOURCEFIELD DATATYPE="string" FIELDNUMBER="1" FIELDPROPERTY="0" 
+                     FIELDTYPE="ELEMITEM" HIDDEN="NO" KEYTYPE="NOT A KEY" 
+                     LENGTH="8" LEVEL="0" NAME="Effective_Date" NULLABLE="NULLABLE" 
+                     OCCURS="0" OFFSET="0" PRECISION="0" SCALE="0" USAGE_FLAGS=""/>
+        <SOURCEFIELD DATATYPE="string" FIELDNUMBER="2" FIELDPROPERTY="0" 
+                     FIELDTYPE="ELEMITEM" HIDDEN="NO" KEYTYPE="NOT A KEY" 
+                     LENGTH="20" LEVEL="0" NAME="Receipt_Number" NULLABLE="NULLABLE" 
+                     OCCURS="0" OFFSET="8" PRECISION="0" SCALE="0" USAGE_FLAGS=""/>
+        <SOURCEFIELD DATATYPE="string" FIELDNUMBER="3" FIELDPROPERTY="0" 
+                     FIELDTYPE="ELEMITEM" HIDDEN="NO" KEYTYPE="NOT A KEY" 
+                     LENGTH="10" LEVEL="0" NAME="Balance_Type" NULLABLE="NULLABLE" 
+                     OCCURS="0" OFFSET="28" PRECISION="0" SCALE="0" USAGE_FLAGS=""/>
+        <SOURCEFIELD DATATYPE="decimal" FIELDNUMBER="4" FIELDPROPERTY="0" 
+                     FIELDTYPE="ELEMITEM" HIDDEN="NO" KEYTYPE="NOT A KEY" 
+                     LENGTH="15" LEVEL="0" NAME="Amount" NULLABLE="NULLABLE" 
+                     OCCURS="0" OFFSET="38" PRECISION="15" SCALE="3" USAGE_FLAGS=""/>
+        <SOURCEFIELD DATATYPE="string" FIELDNUMBER="5" FIELDPROPERTY="0" 
+                     FIELDTYPE="ELEMITEM" HIDDEN="NO" KEYTYPE="NOT A KEY" 
+                     LENGTH="20" LEVEL="0" NAME="Account" NULLABLE="NULLABLE" 
+                     OCCURS="0" OFFSET="53" PRECISION="0" SCALE="0" USAGE_FLAGS=""/>
+      </SOURCE>
+
+      <!-- TARGET DEFINITION: PS_HBC_INV_BAL_STG Table -->
+      <TARGET NAME="PS_HBC_INV_BAL_STG" DATABASETYPE="Oracle" TABLEOPTIONS="TRUNCATE TABLE">
+        <TARGETFIELD BUSINESSNAME="" DATATYPE="string" FIELDNUMBER="1" 
+                     KEYTYPE="NOT A KEY" NAME="FI_INSTRUMENT_ID" NULLABLE="NOT NULL" 
+                     PRECISION="45" SCALE="0"/>
+        <TARGETFIELD BUSINESSNAME="" DATATYPE="string" FIELDNUMBER="2" 
+                     KEYTYPE="NOT A KEY" NAME="FI_IBALTYPE_CD" NULLABLE="NULLABLE" 
+                     PRECISION="10" SCALE="0"/>
+        <TARGETFIELD BUSINESSNAME="" DATATYPE="string" FIELDNUMBER="3" 
+                     KEYTYPE="NOT A KEY" NAME="ACCOUNT" NULLABLE="NULLABLE" 
+                     PRECISION="20" SCALE="0"/>
+        <TARGETFIELD BUSINESSNAME="" DATATYPE="bigint" FIELDNUMBER="4" 
+                     KEYTYPE="NOT A KEY" NAME="SEQUENCENO" NULLABLE="NOT NULL" 
+                     PRECISION="10" SCALE="0"/>
+        <TARGETFIELD BUSINESSNAME="" DATATYPE="datetime" FIELDNUMBER="5" 
+                     KEYTYPE="NOT A KEY" NAME="PF_TRANS_DT" NULLABLE="NULLABLE" 
+                     PRECISION="19" SCALE="0"/>
+        <TARGETFIELD BUSINESSNAME="" DATATYPE="string" FIELDNUMBER="6" 
+                     KEYTYPE="NOT A KEY" NAME="HBC_RECEIPT_NO" NULLABLE="NULLABLE" 
+                     PRECISION="20" SCALE="0"/>
+        <TARGETFIELD BUSINESSNAME="" DATATYPE="decimal" FIELDNUMBER="7" 
+                     KEYTYPE="NOT A KEY" NAME="FI_BALANCE_AMT" NULLABLE="NULLABLE" 
+                     PRECISION="15" SCALE="3"/>
+      </TARGET>
+
+      <!-- LOOKUP TABLE DEFINITION: PS_HBC_PERIOD_CTL -->
+      <SOURCE NAME="LKP_PS_HBC_PERIOD_CTL" DATABASETYPE="Oracle" DBDNAME="$PMTargetConnection">
+        <SOURCEFIELD DATATYPE="string" FIELDNUMBER="1" FIELDPROPERTY="0" 
+                     FIELDTYPE="ELEMITEM" HIDDEN="NO" KEYTYPE="NOT A KEY" 
+                     LENGTH="10" LEVEL="0" NAME="HBC_PER_CTL" NULLABLE="NULLABLE" 
+                     OCCURS="0" PRECISION="0" SCALE="0" USAGE_FLAGS=""/>
+        <SOURCEFIELD DATATYPE="datetime" FIELDNUMBER="2" FIELDPROPERTY="0" 
+                     FIELDTYPE="ELEMITEM" HIDDEN="NO" KEYTYPE="NOT A KEY" 
+                     LENGTH="19" LEVEL="0" NAME="HBC_DATA_DATE" NULLABLE="NULLABLE" 
+                     OCCURS="0" PRECISION="0" SCALE="0" USAGE_FLAGS=""/>
+      </SOURCE>
+
+      <!-- SEQUENCE GENERATOR: Global ROW_COUNT -->
+      <TRANSFORMATION NAME="SEQ_ROW_COUNT" TYPE="Sequence Generator">
+        <TRANSFORMFIELD DATATYPE="bigint" DEFAULTVALUE="" FIELDNUMBER="1" 
+                        FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                        KEYTYPE="NOT A KEY" LENGTH="10" LEVEL="0" NAME="NEXTVAL" 
+                        NULLABLE="NOT NULL" OCCURS="0" PRECISION="10" SCALE="0" 
+                        USAGE_FLAGS="OUTPUT"/>
+        <TABLEATTRIBUTE NAME="Start Value" VALUE="1"/>
+        <TABLEATTRIBUTE NAME="Increment By" VALUE="1"/>
+        <TABLEATTRIBUTE NAME="End Value" VALUE="9999999999"/>
+        <TABLEATTRIBUTE NAME="Current Value" VALUE="0"/>
+        <TABLEATTRIBUTE NAME="Cycle" VALUE="NO"/>
+        <TABLEATTRIBUTE NAME="Reset" VALUE="NO"/>
+        <TABLEATTRIBUTE NAME="Number of Cached Values" VALUE="1000"/>
+      </TRANSFORMATION>
+
+      <!-- MAPPING DEFINITION -->
+      <MAPPING NAME="m_BMO_Balance_ETL" DESCRIPTION="Financial Balance ETL Pipeline - PowerCenter Implementation" 
+               ISVALID="YES" OBJECTVERSION="1">
+        
+        <!-- SOURCE QUALIFIER TRANSFORMATION -->
+        <TRANSFORMATION NAME="SQ_mrp0455_inv_gl" TYPE="Source Qualifier">
+          <TRANSFORMFIELD DATATYPE="string" DEFAULTVALUE="" FIELDNUMBER="1" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="8" LEVEL="0" NAME="Effective_Date" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="INPUT/OUTPUT"/>
+          <TRANSFORMFIELD DATATYPE="string" DEFAULTVALUE="" FIELDNUMBER="2" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="20" LEVEL="0" NAME="Receipt_Number" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="INPUT/OUTPUT"/>
+          <TRANSFORMFIELD DATATYPE="string" DEFAULTVALUE="" FIELDNUMBER="3" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="10" LEVEL="0" NAME="Balance_Type" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="INPUT/OUTPUT"/>
+          <TRANSFORMFIELD DATATYPE="decimal" DEFAULTVALUE="" FIELDNUMBER="4" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="15" LEVEL="0" NAME="Amount" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="15" SCALE="3" 
+                          USAGE_FLAGS="INPUT/OUTPUT"/>
+          <TRANSFORMFIELD DATATYPE="string" DEFAULTVALUE="" FIELDNUMBER="5" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="20" LEVEL="0" NAME="Account" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="INPUT/OUTPUT"/>
+          <TABLEATTRIBUTE NAME="Sql Query" VALUE=""/>
+          <TABLEATTRIBUTE NAME="User Defined Join" VALUE=""/>
+          <TABLEATTRIBUTE NAME="Source Filter" VALUE=""/>
+          <TABLEATTRIBUTE NAME="Number Of Sorted Ports" VALUE="0"/>
+          <TABLEATTRIBUTE NAME="Tracing Level" VALUE="Normal"/>
+        </TRANSFORMATION>
+
+        <!-- FILTER TRANSFORMATION: Remove NULL Receipt Numbers -->
+        <TRANSFORMATION NAME="FIL_Remove_Null_Receipts" TYPE="Filter">
+          <TRANSFORMFIELD DATATYPE="string" DEFAULTVALUE="" FIELDNUMBER="1" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="8" LEVEL="0" NAME="Effective_Date" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="INPUT/OUTPUT"/>
+          <TRANSFORMFIELD DATATYPE="string" DEFAULTVALUE="" FIELDNUMBER="2" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="20" LEVEL="0" NAME="Receipt_Number" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="INPUT/OUTPUT"/>
+          <TRANSFORMFIELD DATATYPE="string" DEFAULTVALUE="" FIELDNUMBER="3" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="10" LEVEL="0" NAME="Balance_Type" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="INPUT/OUTPUT"/>
+          <TRANSFORMFIELD DATATYPE="decimal" DEFAULTVALUE="" FIELDNUMBER="4" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="15" LEVEL="0" NAME="Amount" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="15" SCALE="3" 
+                          USAGE_FLAGS="INPUT/OUTPUT"/>
+          <TRANSFORMFIELD DATATYPE="string" DEFAULTVALUE="" FIELDNUMBER="5" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="20" LEVEL="0" NAME="Account" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="INPUT/OUTPUT"/>
+          <TABLEATTRIBUTE NAME="Filter Condition" VALUE="NOT ISNULL(Receipt_Number)"/>
+          <TABLEATTRIBUTE NAME="Tracing Level" VALUE="Normal"/>
+        </TRANSFORMATION>
+
+        <!-- EXPRESSION TRANSFORMATION: Build Lookup Inputs -->
+        <TRANSFORMATION NAME="EXP_Build_For_Lookups" TYPE="Expression">
+          <TRANSFORMFIELD DATATYPE="string" DEFAULTVALUE="" FIELDNUMBER="1" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="8" LEVEL="0" NAME="Effective_Date" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="INPUT/OUTPUT"/>
+          <TRANSFORMFIELD DATATYPE="string" DEFAULTVALUE="" FIELDNUMBER="2" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="20" LEVEL="0" NAME="Receipt_Number" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="INPUT/OUTPUT"/>
+          <TRANSFORMFIELD DATATYPE="string" DEFAULTVALUE="" FIELDNUMBER="3" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="10" LEVEL="0" NAME="Balance_Type" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="INPUT/OUTPUT"/>
+          <TRANSFORMFIELD DATATYPE="decimal" DEFAULTVALUE="" FIELDNUMBER="4" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="15" LEVEL="0" NAME="Amount" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="15" SCALE="3" 
+                          USAGE_FLAGS="INPUT/OUTPUT"/>
+          <TRANSFORMFIELD DATATYPE="string" DEFAULTVALUE="" FIELDNUMBER="5" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="20" LEVEL="0" NAME="Account" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="INPUT/OUTPUT"/>
+          <TRANSFORMFIELD DATATYPE="string" DEFAULTVALUE="" FIELDNUMBER="6" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="10" LEVEL="0" NAME="lkp_HBC_PER_CTL" 
+                          NULLABLE="NOT NULL" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="OUTPUT"/>
+          <TABLEATTRIBUTE NAME="Expression" VALUE="lkp_HBC_PER_CTL = RTRIM('APS')"/>
+          <TABLEATTRIBUTE NAME="Tracing Level" VALUE="Normal"/>
+        </TRANSFORMATION>
+
+        <!-- LOOKUP TRANSFORMATION: PS_HBC_PERIOD_CTL -->
+        <TRANSFORMATION NAME="LKP_HBC_PERIOD_CTL" TYPE="Lookup">
+          <TRANSFORMFIELD DATATYPE="string" DEFAULTVALUE="" FIELDNUMBER="1" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="10" LEVEL="0" NAME="lkp_HBC_PER_CTL" 
+                          NULLABLE="NOT NULL" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="INPUT"/>
+          <TRANSFORMFIELD DATATYPE="datetime" DEFAULTVALUE="" FIELDNUMBER="2" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="19" LEVEL="0" NAME="HBC_DATA_DATE" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="OUTPUT"/>
+          <TABLEATTRIBUTE NAME="Sql Override" VALUE="SELECT HBC_DATA_DATE FROM PS_HBC_PERIOD_CTL WHERE RTRIM(HBC_PER_CTL) = ?"/>
+          <TABLEATTRIBUTE NAME="Lookup Policy On Multiple Match" VALUE="Use First Value"/>
+          <TABLEATTRIBUTE NAME="Lookup Policy On Null Lookup" VALUE="Ignore Null Values"/>
+          <TABLEATTRIBUTE NAME="Lookup Caching" VALUE="Enabled"/>
+          <TABLEATTRIBUTE NAME="Lookup Cache Persistent" VALUE="Disabled"/>
+          <TABLEATTRIBUTE NAME="Lookup Cache Recache From Database" VALUE="Disabled"/>
+          <TABLEATTRIBUTE NAME="Tracing Level" VALUE="Normal"/>
+        </TRANSFORMATION>
+
+        <!-- EXPRESSION TRANSFORMATION: Date Validation and Field Construction -->
+        <TRANSFORMATION NAME="EXP_Check_Date_Build_Table" TYPE="Expression">
+          <TRANSFORMFIELD DATATYPE="string" DEFAULTVALUE="" FIELDNUMBER="1" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="8" LEVEL="0" NAME="Effective_Date" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="INPUT"/>
+          <TRANSFORMFIELD DATATYPE="string" DEFAULTVALUE="" FIELDNUMBER="2" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="20" LEVEL="0" NAME="Receipt_Number" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="INPUT"/>
+          <TRANSFORMFIELD DATATYPE="string" DEFAULTVALUE="" FIELDNUMBER="3" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="10" LEVEL="0" NAME="Balance_Type" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="INPUT"/>
+          <TRANSFORMFIELD DATATYPE="decimal" DEFAULTVALUE="" FIELDNUMBER="4" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="15" LEVEL="0" NAME="Amount" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="15" SCALE="3" 
+                          USAGE_FLAGS="INPUT"/>
+          <TRANSFORMFIELD DATATYPE="string" DEFAULTVALUE="" FIELDNUMBER="5" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="20" LEVEL="0" NAME="Account" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="INPUT"/>
+          <TRANSFORMFIELD DATATYPE="datetime" DEFAULTVALUE="" FIELDNUMBER="6" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="19" LEVEL="0" NAME="HBC_DATA_DATE" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="INPUT"/>
+          <TRANSFORMFIELD DATATYPE="bigint" DEFAULTVALUE="" FIELDNUMBER="7" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="10" LEVEL="0" NAME="NEXTVAL" 
+                          NULLABLE="NOT NULL" OCCURS="0" PRECISION="10" SCALE="0" 
+                          USAGE_FLAGS="INPUT"/>
+          
+          <!-- Variable Ports -->
+          <TRANSFORMFIELD DATATYPE="datetime" DEFAULTVALUE="" FIELDNUMBER="8" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="19" LEVEL="0" NAME="var_Header_Date" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="VARIABLE"/>
+          
+          <!-- Output Ports -->
+          <TRANSFORMFIELD DATATYPE="string" DEFAULTVALUE="" FIELDNUMBER="9" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="45" LEVEL="0" NAME="FI_INSTRUMENT_ID" 
+                          NULLABLE="NOT NULL" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="OUTPUT"/>
+          <TRANSFORMFIELD DATATYPE="string" DEFAULTVALUE="" FIELDNUMBER="10" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="10" LEVEL="0" NAME="FI_IBALTYPE_CD" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="OUTPUT"/>
+          <TRANSFORMFIELD DATATYPE="string" DEFAULTVALUE="" FIELDNUMBER="11" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="20" LEVEL="0" NAME="ACCOUNT" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="OUTPUT"/>
+          <TRANSFORMFIELD DATATYPE="bigint" DEFAULTVALUE="" FIELDNUMBER="12" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="10" LEVEL="0" NAME="SEQUENCENO" 
+                          NULLABLE="NOT NULL" OCCURS="0" PRECISION="10" SCALE="0" 
+                          USAGE_FLAGS="OUTPUT"/>
+          <TRANSFORMFIELD DATATYPE="datetime" DEFAULTVALUE="" FIELDNUMBER="13" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="19" LEVEL="0" NAME="PF_TRANS_DT" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="OUTPUT"/>
+          <TRANSFORMFIELD DATATYPE="string" DEFAULTVALUE="" FIELDNUMBER="14" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="20" LEVEL="0" NAME="HBC_RECEIPT_NO" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="0" SCALE="0" 
+                          USAGE_FLAGS="OUTPUT"/>
+          <TRANSFORMFIELD DATATYPE="decimal" DEFAULTVALUE="" FIELDNUMBER="15" 
+                          FIELDPROPERTY="0" FIELDTYPE="ELEMITEM" HIDDEN="NO" 
+                          KEYTYPE="NOT A KEY" LENGTH="15" LEVEL="0" NAME="FI_BALANCE_AMT" 
+                          NULLABLE="NULLABLE" OCCURS="0" PRECISION="15" SCALE="3" 
+                          USAGE_FLAGS="OUTPUT"/>
+
+          <!-- Expression Logic -->
+          <TABLEATTRIBUTE NAME="Expression" VALUE="
+            -- Variable: Parse effective date from string
+            var_Header_Date = TO_DATE(Effective_Date, 'YYYYMMDD')
+            
+            -- Date validation with abort logic
+            IIF(var_Header_Date != HBC_DATA_DATE, 
+                ABORT('Intrader Effective Date does not equal the HBC_DATA_DATE on the APS Period Control row'), 
+                NULL)
+            
+            -- Output Field Expressions:
+            FI_INSTRUMENT_ID = 'INV' || LPAD(Receipt_Number, 42, '0')
+            
+            FI_IBALTYPE_CD = IIF(ISNULL(Balance_Type), 
+                                ' ', 
+                                CHR(10) || UPPER(Balance_Type))
+            
+            ACCOUNT = IIF(ISNULL(Account), ' ', Account)
+            
+            SEQUENCENO = NEXTVAL
+            
+            PF_TRANS_DT = HBC_DATA_DATE
+            
+            HBC_RECEIPT_NO = IIF(ISNULL(Receipt_Number), 
+                                ' ', 
+                                CHR(10) || Receipt_Number)
+            
+            FI_BALANCE_AMT = IIF(ISNULL(Amount), 
+                                0.000, 
+                                TO_DECIMAL(Amount, 15, 3))
+          "/>
+          <TABLEATTRIBUTE NAME="Tracing Level" VALUE="Normal"/>
+        </TRANSFORMATION>
+
+        <!-- CONNECTOR DEFINITIONS -->
+        <CONNECTOR FROMFIELD="Effective_Date" FROMINSTANCE="SQ_mrp0455_inv_gl" 
+                   FROMINSTANCETYPE="Source Qualifier" TOFIELD="Effective_Date" 
+                   TOINSTANCE="FIL_Remove_Null_Receipts" TOINSTANCETYPE="Filter"/>
+        <CONNECTOR FROMFIELD="Receipt_Number" FROMINSTANCE="SQ_mrp0455_inv_gl" 
+                   FROMINSTANCETYPE="Source Qualifier" TOFIELD="Receipt_Number" 
+                   TOINSTANCE="FIL_Remove_Null_Receipts" TOINSTANCETYPE="Filter"/>
+        <CONNECTOR FROMFIELD="Balance_Type" FROMINSTANCE="SQ_mrp0455_inv_gl" 
+                   FROMINSTANCETYPE="Source Qualifier" TOFIELD="Balance_Type" 
+                   TOINSTANCE="FIL_Remove_Null_Receipts" TOINSTANCETYPE="Filter"/>
+        <CONNECTOR FROMFIELD="Amount" FROMINSTANCE="SQ_mrp0455_inv_gl" 
+                   FROMINSTANCETYPE="Source Qualifier" TOFIELD="Amount" 
+                   TOINSTANCE="FIL_Remove_Null_Receipts" TOINSTANCETYPE="Filter"/>
+        <CONNECTOR FROMFIELD="Account" FROMINSTANCE="SQ_mrp0455_inv_gl" 
+                   FROMINSTANCETYPE="Source Qualifier" TOFIELD="Account" 
+                   TOINSTANCE="FIL_Remove_Null_Receipts" TOINSTANCETYPE="Filter"/>
+
+        <CONNECTOR FROMFIELD="Effective_Date" FROMINSTANCE="FIL_Remove_Null_Receipts" 
+                   FROMINSTANCETYPE="Filter" TOFIELD="Effective_Date" 
+                   TOINSTANCE="EXP_Build_For_Lookups" TOINSTANCETYPE="Expression"/>
+        <CONNECTOR FROMFIELD="Receipt_Number" FROMINSTANCE="FIL_Remove_Null_Receipts" 
+                   FROMINSTANCETYPE="Filter" TOFIELD="Receipt_Number" 
+                   TOINSTANCE="EXP_Build_For_Lookups" TOINSTANCETYPE="Expression"/>
+        <CONNECTOR FROMFIELD="Balance_Type" FROMINSTANCE="FIL_Remove_Null_Receipts" 
+                   FROMINSTANCETYPE="Filter" TOFIELD="Balance_Type" 
+                   TOINSTANCE="EXP_Build_For_Lookups" TOINSTANCETYPE="Expression"/>
+        <CONNECTOR FROMFIELD="Amount" FROMINSTANCE="FIL_Remove_Null_Receipts" 
+                   FROMINSTANCETYPE="Filter" TOFIELD="Amount" 
+                   TOINSTANCE="EXP_Build_For_Lookups" TOINSTANCETYPE="Expression"/>
+        <CONNECTOR FROMFIELD="Account" FROMINSTANCE="FIL_Remove_Null_Receipts" 
+                   FROMINSTANCETYPE="Filter" TOFIELD="Account" 
+                   TOINSTANCE="EXP_Build_For_Lookups" TOINSTANCETYPE="Expression"/>
+
+        <CONNECTOR FROMFIELD="lkp_HBC_PER_CTL" FROMINSTANCE="EXP_Build_For_Lookups" 
+                   FROMINSTANCETYPE="Expression" TOFIELD="lkp_HBC_PER_CTL" 
+                   TOINSTANCE="LKP_HBC_PERIOD_CTL" TOINSTANCETYPE="Lookup"/>
+
+        <CONNECTOR FROMFIELD="Effective_Date" FROMINSTANCE="EXP_Build_For_Lookups" 
+                   FROMINSTANCETYPE="Expression" TOFIELD="Effective_Date" 
+                   TOINSTANCE="EXP_Check_Date_Build_Table" TOINSTANCETYPE="Expression"/>
+        <CONNECTOR FROMFIELD="Receipt_Number" FROMINSTANCE="EXP_Build_For_Lookups" 
+                   FROMINSTANCETYPE="Expression" TOFIELD="Receipt_Number" 
+                   TOINSTANCE="EXP_Check_Date_Build_Table" TOINSTANCETYPE="Expression"/>
+        <CONNECTOR FROMFIELD="Balance_Type" FROMINSTANCE="EXP_Build_For_Lookups" 
+                   FROMINSTANCETYPE="Expression" TOFIELD="Balance_Type" 
+                   TOINSTANCE="EXP_Check_Date_Build_Table" TOINSTANCETYPE="Expression"/>
+        <CONNECTOR FROMFIELD="Amount" FROMINSTANCE="EXP_Build_For_Lookups" 
+                   FROMINSTANCETYPE="Expression" TOFIELD="Amount" 
+                   TOINSTANCE="EXP_Check_Date_Build_Table" TOINSTANCETYPE="Expression"/>
+        <CONNECTOR FROMFIELD="Account" FROMINSTANCE="EXP_Build_For_Lookups" 
+                   FROMINSTANCETYPE="Expression" TOFIELD="Account" 
+                   TOINSTANCE="EXP_Check_Date_Build_Table" TOINSTANCETYPE="Expression"/>
+
+        <CONNECTOR FROMFIELD="HBC_DATA_DATE" FROMINSTANCE="LKP_HBC_PERIOD_CTL" 
+                   FROMINSTANCETYPE="Lookup" TOFIELD="HBC_DATA_DATE" 
+                   TOINSTANCE="EXP_Check_Date_Build_Table" TOINSTANCETYPE="Expression"/>
+
+        <CONNECTOR FROMFIELD="NEXTVAL" FROMINSTANCE="SEQ_ROW_COUNT" 
+                   FROMINSTANCETYPE="Sequence Generator" TOFIELD="NEXTVAL" 
+                   TOINSTANCE="EXP_Check_Date_Build_Table" TOINSTANCETYPE="Expression"/>
+
+        <CONNECTOR FROMFIELD="FI_INSTRUMENT_ID" FROMINSTANCE="EXP_Check_Date_Build_Table" 
+                   FROMINSTANCETYPE="Expression" TOFIELD="FI_INSTRUMENT_ID" 
+                   TOINSTANCE="PS_HBC_INV_BAL_STG" TOINSTANCETYPE="Target"/>
+        <CONNECTOR FROMFIELD="FI_IBALTYPE_CD" FROMINSTANCE="EXP_Check_Date_Build_Table" 
+                   FROMINSTANCETYPE="Expression" TOFIELD="FI_IBALTYPE_CD" 
+                   TOINSTANCE="PS_HBC_INV_BAL_STG" TOINSTANCETYPE="Target"/>
+        <CONNECTOR FROMFIELD="ACCOUNT" FROMINSTANCE="EXP_Check_Date_Build_Table" 
+                   FROMINSTANCETYPE="Expression" TOFIELD="ACCOUNT" 
+                   TOINSTANCE="PS_HBC_INV_BAL_STG" TOINSTANCETYPE="Target"/>
+        <CONNECTOR FROMFIELD="SEQUENCENO" FROMINSTANCE="EXP_Check_Date_Build_Table" 
+                   FROMINSTANCETYPE="Expression" TOFIELD="SEQUENCENO" 
+                   TOINSTANCE="PS_HBC_INV_BAL_STG" TOINSTANCETYPE="Target"/>
+        <CONNECTOR FROMFIELD="PF_TRANS_DT" FROMINSTANCE="EXP_Check_Date_Build_Table" 
+                   FROMINSTANCETYPE="Expression" TOFIELD="PF_TRANS_DT" 
+                   TOINSTANCE="PS_HBC_INV_BAL_STG" TOINSTANCETYPE="Target"/>
+        <CONNECTOR FROMFIELD="HBC_RECEIPT_NO" FROMINSTANCE="EXP_Check_Date_Build_Table" 
+                   FROMINSTANCETYPE="Expression" TOFIELD="HBC_RECEIPT_NO" 
+                   TOINSTANCE="PS_HBC_INV_BAL_STG" TOINSTANCETYPE="Target"/>
+        <CONNECTOR FROMFIELD="FI_BALANCE_AMT" FROMINSTANCE="EXP_Check_Date_Build_Table" 
+                   FROMINSTANCETYPE="Expression" TOFIELD="FI_BALANCE_AMT" 
+                   TOINSTANCE="PS_HBC_INV_BAL_STG" TOINSTANCETYPE="Target"/>
+
+      </MAPPING>
+    </FOLDER>
+  </REPOSITORY>
+</POWERMART>

--- a/PowerCenter_Implementation_Guide.md
+++ b/PowerCenter_Implementation_Guide.md
@@ -1,0 +1,143 @@
+# Informatica PowerCenter Implementation Guide
+## BMO Financial Balance ETL Pipeline
+
+### Overview
+This document provides the Informatica PowerCenter implementation for the financial balance ETL pipeline based on the pseudo-code in `pseudo_ETL_code.txt`. The implementation translates each pseudo-code component into corresponding PowerCenter transformations.
+
+### Mapping Architecture
+
+#### Data Flow Sequence
+1. **Source Qualifier** → **Filter** → **Expression (Build Lookups)** → **Lookup** → **Expression (Date Validation & Field Construction)** → **Target**
+2. **Sequence Generator** → **Expression (Date Validation & Field Construction)**
+
+### Transformation Details
+
+#### 1. Source Definition: `SQ_mrp0455_inv_gl`
+- **Type**: Flat File Source
+- **File**: `mrp0455_inv_gl.txt`
+- **Fields**:
+  - `Effective_Date` (String, 8 chars)
+  - `Receipt_Number` (String, 20 chars)
+  - `Balance_Type` (String, 10 chars)
+  - `Amount` (Decimal, 15,3)
+  - `Account` (String, 20 chars)
+
+#### 2. Filter Transformation: `FIL_Remove_Null_Receipts`
+- **Purpose**: Implements `filter_rows()` function from pseudo-code
+- **Condition**: `NOT ISNULL(Receipt_Number)`
+- **Logic**: Filters out records where Receipt_Number is NULL
+
+#### 3. Expression Transformation: `EXP_Build_For_Lookups`
+- **Purpose**: Implements `exp_build_for_lookups()` function
+- **Key Logic**:
+  - Passes through all source fields
+  - Creates lookup input: `lkp_HBC_PER_CTL = RTRIM('APS')`
+
+#### 4. Lookup Transformation: `LKP_HBC_PERIOD_CTL`
+- **Purpose**: Implements `lookup_HBC_PERIOD_CTL()` function
+- **Source Table**: `PS_HBC_PERIOD_CTL`
+- **SQL Override**: 
+  ```sql
+  SELECT HBC_DATA_DATE 
+  FROM PS_HBC_PERIOD_CTL 
+  WHERE RTRIM(HBC_PER_CTL) = ?
+  ```
+- **Lookup Condition**: `lkp_HBC_PER_CTL`
+- **Return Value**: `HBC_DATA_DATE`
+
+#### 5. Sequence Generator: `SEQ_ROW_COUNT`
+- **Purpose**: Implements global `ROW_COUNT` variable
+- **Configuration**:
+  - Start Value: 1
+  - Increment By: 1
+  - Cache Size: 1000
+- **Output**: `NEXTVAL` (used as SEQUENCENO)
+
+#### 6. Expression Transformation: `EXP_Check_Date_Build_Table`
+- **Purpose**: Implements `exp_check_date_build_table()` function
+- **Critical Business Logic**:
+
+##### Date Validation with Abort Logic
+```sql
+-- Variable Port
+var_Header_Date = TO_DATE(Effective_Date, 'YYYYMMDD')
+
+-- Abort Logic
+IIF(var_Header_Date != HBC_DATA_DATE, 
+    ABORT('Intrader Effective Date does not equal the HBC_DATA_DATE on the APS Period Control row'), 
+    NULL)
+```
+
+##### Field Transformations
+```sql
+-- FI_INSTRUMENT_ID: "INV" + left-padded Receipt_Number to 42 digits
+FI_INSTRUMENT_ID = 'INV' || LPAD(Receipt_Number, 42, '0')
+
+-- FI_IBALTYPE_CD: NULL handling with space default, uppercase conversion
+FI_IBALTYPE_CD = IIF(ISNULL(Balance_Type), ' ', CHR(10) || UPPER(Balance_Type))
+
+-- ACCOUNT: NULL handling with space default
+ACCOUNT = IIF(ISNULL(Account), ' ', Account)
+
+-- SEQUENCENO: Global sequence from Sequence Generator
+SEQUENCENO = NEXTVAL
+
+-- PF_TRANS_DT: Date from lookup
+PF_TRANS_DT = HBC_DATA_DATE
+
+-- HBC_RECEIPT_NO: NULL handling with space default
+HBC_RECEIPT_NO = IIF(ISNULL(Receipt_Number), ' ', CHR(10) || Receipt_Number)
+
+-- FI_BALANCE_AMT: Decimal conversion with NULL handling
+FI_BALANCE_AMT = IIF(ISNULL(Amount), 0.000, TO_DECIMAL(Amount, 15, 3))
+```
+
+#### 7. Target Definition: `PS_HBC_INV_BAL_STG`
+- **Type**: Oracle Database Table
+- **Load Type**: Insert
+- **Table Option**: Truncate Table (optional)
+- **Fields**:
+  - `FI_INSTRUMENT_ID` (String, 45 chars, NOT NULL)
+  - `FI_IBALTYPE_CD` (String, 10 chars, NULLABLE)
+  - `ACCOUNT` (String, 20 chars, NULLABLE)
+  - `SEQUENCENO` (BigInt, NOT NULL)
+  - `PF_TRANS_DT` (DateTime, NULLABLE)
+  - `HBC_RECEIPT_NO` (String, 20 chars, NULLABLE)
+  - `FI_BALANCE_AMT` (Decimal 15,3, NULLABLE)
+
+### Key Implementation Notes
+
+#### Critical Business Rules Preserved
+1. **Date Validation Abort**: The mapping will abort if `Effective_Date` ≠ `HBC_DATA_DATE`
+2. **Sequence Integrity**: Global `ROW_COUNT` maintained via Sequence Generator
+3. **Field Padding**: `FI_INSTRUMENT_ID` properly padded to 42 digits with leading zeros
+4. **NULL Handling**: Consistent NULL handling across all fields as per pseudo-code
+
+#### PowerCenter-Specific Considerations
+1. **Lookup Caching**: Enabled for performance (PS_HBC_PERIOD_CTL lookup)
+2. **Error Handling**: ABORT() function stops session execution on date mismatch
+3. **Data Types**: Proper mapping of string, decimal, and datetime types
+4. **Connection Strategy**: Sequence Generator connected to ensure proper sequencing
+
+#### Session Configuration Recommendations
+1. **Commit Interval**: Set based on data volume (e.g., 10,000 rows)
+2. **Error Handling**: Stop on errors due to critical date validation
+3. **Performance**: Enable lookup caching and appropriate buffer sizes
+4. **Logging**: Enable session logging for troubleshooting
+
+### Deployment Steps
+1. Import source and target definitions
+2. Create lookup table definition for PS_HBC_PERIOD_CTL
+3. Build mapping with transformations as specified
+4. Configure session with appropriate connection information
+5. Create workflow with session
+6. Validate mapping logic and test with sample data
+
+### Testing Strategy
+1. **Unit Testing**: Test each transformation individually
+2. **Date Validation**: Verify abort logic with mismatched dates
+3. **NULL Handling**: Test with NULL values in all fields
+4. **Sequence Generation**: Verify proper incrementing of ROW_COUNT
+5. **Field Formatting**: Validate padding and case conversion logic
+
+This implementation maintains full fidelity to the original pseudo-code while leveraging PowerCenter's native transformation capabilities for optimal performance and maintainability.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,66 @@
-# test-BMO-Informatica
+# Informatica PowerCenter ETL Implementation
+
+This repository contains a comprehensive Informatica PowerCenter implementation for a financial balance ETL pipeline, based on pseudo-code specifications.
+
+## Overview
+
+This project demonstrates how to translate pseudo-code ETL logic into a complete Informatica PowerCenter mapping with all necessary transformations, business rules, and data flow components.
+
+## Files
+
+- **`Informatica_PowerCenter_Mapping.xml`** - Complete PowerCenter mapping XML with all transformations
+- **`PowerCenter_Implementation_Guide.md`** - Detailed implementation guide with transformation specifications
+- **`pseudo_ETL_code.txt`** - Original pseudo-code that served as the basis for the PowerCenter implementation
+
+## ETL Pipeline Components
+
+### Source
+- **Flat File**: `mrp0455_inv_gl.txt`
+- **Fields**: Effective_Date, Receipt_Number, Balance_Type, Amount, Account
+
+### Target
+- **Table**: `PS_HBC_INV_BAL_STG`
+- **Columns**: FI_INSTRUMENT_ID, FI_IBALTYPE_CD, ACCOUNT, SEQUENCENO, PF_TRANS_DT, HBC_RECEIPT_NO, FI_BALANCE_AMT
+
+### Key Transformations
+
+1. **Filter Transformation**: Removes records with NULL receipt numbers
+2. **Lookup Transformation**: Validates dates against `PS_HBC_PERIOD_CTL` table
+3. **Expression Transformations**: 
+   - Date validation with abort logic
+   - Field construction and formatting
+   - NULL handling and data type conversions
+4. **Sequence Generator**: Global ROW_COUNT for record sequencing
+
+### Critical Business Logic
+
+- **Date Validation**: Session aborts if Effective_Date ≠ HBC_DATA_DATE
+- **Field Padding**: FI_INSTRUMENT_ID = "INV" + left-padded Receipt_Number to 42 digits
+- **NULL Handling**: Consistent space defaults and proper null checks
+- **Decimal Conversion**: FI_BALANCE_AMT with 3 decimal places
+
+## Implementation Features
+
+- Complete PowerCenter XML mapping definition
+- All transformation logic preserved from pseudo-code
+- Proper field mappings and data type handling
+- Error handling with abort conditions
+- Sequence generation for record tracking
+
+## Usage
+
+1. Import the XML mapping into your Informatica PowerCenter environment
+2. Configure source and target connections
+3. Review the implementation guide for detailed transformation specifications
+4. Test with sample data to validate the ETL logic
+
+## Architecture
+
+The mapping follows a standard ETL pattern:
+```
+Source → Filter → Expression → Lookup → Expression → Target
+                                ↑
+                        Sequence Generator
+```
+
+This implementation serves as a proof of concept for translating pseudo-code ETL specifications into production-ready Informatica PowerCenter mappings.

--- a/pseudo_ETL_code.txt
+++ b/pseudo_ETL_code.txt
@@ -1,0 +1,124 @@
+ // Global row counter for sequencing
+var ROW_COUNT := 0
+
+// Entry point of the mapping
+function process_mapping():
+    for each record in read_source_file():
+        // 1. Extract source fields
+        data := {
+            Effective_Date   : record.Effective_Date,
+            Receipt_Number   : record.Receipt_Number,
+            Balance_Type     : record.Balance_Type,
+            Amount           : record.Amount,
+            Account          : record.Account
+        }
+
+        // 2. Filter out rows with NULL receipt number
+        if not filter_rows(data):
+            continue
+
+        // 3. Build inputs for lookup
+        lookup_input := exp_build_for_lookups(data)
+
+        // 4. Perform lookup to retrieve HBC_DATA_DATE
+        lookup_input.HBC_DATA_DATE := lookup_HBC_PERIOD_CTL(lookup_input.lkp_HBC_PER_CTL)
+
+        // 5. Apply business logic, increment sequence, and construct target fields
+        output := exp_check_date_build_table(lookup_input)
+
+        // 6. Load the row into target table
+        load_target(output)
+
+    end for
+end function
+
+
+// --- Transformation Definitions ---
+
+
+// Filter transformation: passes only non‐null receipts
+function filter_rows(data):
+    return data.Receipt_Number is not NULL
+end function
+
+
+// Expression transformation: prepares lookup input
+function exp_build_for_lookups(data):
+    return {
+        Effective_Date   : data.Effective_Date,
+        Receipt_Number   : data.Receipt_Number,
+        Balance_Type     : data.Balance_Type,
+        Amount           : data.Amount,
+        Account          : data.Account,
+        // constant input for period‐control lookup
+        lkp_HBC_PER_CTL  : rtrim("APS")
+    }
+end function
+
+
+// Lookup transformation: fetches control‐period date
+function lookup_HBC_PERIOD_CTL(in_HBC_PER_CTL):
+    // SQL override:
+    // SELECT HBC_DATA_DATE
+    //   FROM PS_HBC_PERIOD_CTL
+    //  WHERE RTRIM(HBC_PER_CTL) = in_HBC_PER_CTL
+    return execute_sql_and_get_single_value(...)
+end function
+
+
+// Expression transformation: validates dates, increments row counter, builds target columns
+function exp_check_date_build_table(input):
+    // Parse effective date from string
+    var_Header_Date := to_date(input.Effective_Date, "YYYYMMDD")
+
+    // Abort if dates do not match
+    if var_Header_Date != input.HBC_DATA_DATE:
+        abort("Intrader Effective Date does not equal the HBC_DATA_DATE on the APS Period Control row")
+
+    // Increment global sequence
+    ROW_COUNT := ROW_COUNT + 1
+
+    // Build output record
+    return {
+        FI_INSTRUMENT_ID : "INV" + lpad(input.Receipt_Number, 42, "0"),
+        FI_IBALTYPE_CD   : if input.Balance_Type is NULL
+                            then " "
+                            else "\n" + upper(input.Balance_Type),
+        ACCOUNT          : if input.Account is NULL
+                            then " "
+                            else input.Account,
+        SEQUENCENO       : ROW_COUNT,
+        PF_TRANS_DT      : input.HBC_DATA_DATE,
+        HBC_RECEIPT_NO   : if input.Receipt_Number is NULL
+                            then " "
+                            else "\n" + input.Receipt_Number,
+        FI_BALANCE_AMT   : if input.Amount is NULL
+                            then 0.000
+                            else to_decimal(input.Amount, 3)
+    }
+end function
+
+
+// Target loading: inserts or updates the target table row
+function load_target(output):
+    // INSERT INTO PS_HBC_INV_BAL_STG (
+    //   FI_INSTRUMENT_ID,
+    //   FI_IBALTYPE_CD,
+    //   ACCOUNT,
+    //   SEQUENCENO,
+    //   PF_TRANS_DT,
+    //   HBC_RECEIPT_NO,
+    //   FI_BALANCE_AMT
+    // ) VALUES ( ... )
+    execute_target_insert(output)
+end function
+
+
+// Utility: reads from the flat‐file source “Balance”
+function read_source_file():
+    // Open the file mrp0455_inv_gl.txt
+    // Parse each line into a record with fields:
+    //   Effective_Date, Receipt_Number, Balance_Type, Amount, Account
+    // Skip header row
+    yield each record
+end function


### PR DESCRIPTION
- Add comprehensive PowerCenter mapping XML with all transformations
- Include detailed implementation guide with transformation specifications
- Add original pseudo-code reference file
- Update README with project overview and usage instructions

Features:
- Source definition for mrp0455_inv_gl.txt flat file
- Target definition for PS_HBC_INV_BAL_STG table
- Filter transformation to remove NULL receipt numbers
- Lookup transformation for PS_HBC_PERIOD_CTL date validation
- Expression transformations for field mappings and business logic
- Sequence generator for global ROW_COUNT variable
- Critical business logic: date validation abort, field padding, NULL handling